### PR TITLE
メッセージ投稿機能の実装

### DIFF
--- a/app/assets/stylesheets/room.css
+++ b/app/assets/stylesheets/room.css
@@ -89,3 +89,7 @@ select {
   height: 80px;
   width: 100%;
 }
+
+.field_with_errors {
+  display: contents;
+}

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -1,7 +1,9 @@
 class MessagesController < ApplicationController
+
   def index
      @message = Message.new
      @room = Room.find(params[:room_id])
+     @messages = @room.messages.includes(:user)
    end
  
    def create
@@ -10,10 +12,10 @@ class MessagesController < ApplicationController
      if @message.save
        redirect_to room_messages_path(@room)
      else
+       @messages = @room.messages.includes(:user)
        render :index
      end
    end
- 
  
    private
  

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -1,4 +1,23 @@
 class MessagesController < ApplicationController
   def index
-  end
-end
+     @message = Message.new
+     @room = Room.find(params[:room_id])
+   end
+ 
+   def create
+     @room = Room.find(params[:room_id])
+     @message = @room.messages.new(message_params)
+     if @message.save
+       redirect_to room_messages_path(@room)
+     else
+       render :index
+     end
+   end
+ 
+ 
+   private
+ 
+   def message_params
+     params.require(:message).permit(:content).merge(user_id: current_user.id)
+   end
+ end

--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -1,13 +1,20 @@
 class RoomsController < ApplicationController
-
-  def index
-  end
-
   def new
     @room = Room.new
   end
 
   def create
+    @room = Room.new(room_params)
+    if @room.save
+      redirect_to root_path
+    else
+      render :new
+    end
   end
 
+  private
+
+  def room_params
+    params.require(:room).permit(:name, user_ids: [])
+  end
 end

--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -1,4 +1,9 @@
 class RoomsController < ApplicationController
+
+  def index
+
+  end
+
   def new
     @room = Room.new
   end
@@ -12,9 +17,15 @@ class RoomsController < ApplicationController
     end
   end
 
+  def destroy
+    room = Room.find(params[:id])
+    room.destroy
+    redirect_to root_path
+  end
+
   private
 
   def room_params
-    params.require(:room).permit(:name, user_ids: [])
+    params.require(:room).permit(:name, user_ids:[])
   end
 end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,0 +1,4 @@
+class Message < ApplicationRecord
+  belongs_to :room
+  belongs_to :user
+end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,4 +1,6 @@
 class Message < ApplicationRecord
   belongs_to :room
   belongs_to :user
+
+  validates :content, presence: true
 end

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -1,6 +1,7 @@
 class Room < ApplicationRecord
   has_many :room_users
   has_many :users, through: :room_users
+  has_many :messages
 
   validates :name, presence: true
 

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -1,8 +1,7 @@
 class Room < ApplicationRecord
-  has_many :room_users
-  has_many :users, through: :room_users
-  has_many :messages
+  has_many :room_users, dependent: :destroy
+  has_many :users, through: :room_users  
+  has_many :messages, dependent: :destroy
 
   validates :name, presence: true
-
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,4 +7,6 @@ class User < ApplicationRecord
 
   has_many :room_users
   has_many :rooms, through: :room_users
+  has_many :messages
+
 end

--- a/app/views/messages/_main_chat.html.erb
+++ b/app/views/messages/_main_chat.html.erb
@@ -6,7 +6,7 @@
   </div>
   <div class="right-header">
     <div class="header-button">
-      <a href="#">チャットを終了する</a>
+      <%= link_to "チャットを終了する", room_path(@room), method: :delete %>
     </div>
   </div>
 </div>

--- a/app/views/messages/_main_chat.html.erb
+++ b/app/views/messages/_main_chat.html.erb
@@ -1,7 +1,7 @@
 <div class="chat-header">
   <div class="left-header">
     <div class="header-title">
-      hogefuga
+      <%= @room.name %>
     </div>
   </div>
   <div class="right-header">

--- a/app/views/messages/_main_chat.html.erb
+++ b/app/views/messages/_main_chat.html.erb
@@ -28,31 +28,13 @@
     </div>
   </div>
 
-  <div class="message">
-    <div class="upper-message">
-      <div class="message-user">
-        Tom
-      </div>
-      <div class="message-date">
-        2020/3/31(Wed) 12:47:30
-      </div>
-    </div>
-    <div class="lower-message">
-      <div class="message-content">
-        こんばんは
-      </div>
-    </div>
-  </div>
-</div>
-
-
-<div class="form">
+<%= form_with model: [@room, @message], class: 'form', local: true do |f| %>
   <div class="form-input">
-    <input class="form-message" placeholder= "type a message">
+    <%= f.text_field :content, class: 'form-message', placeholder: 'type a message' %>
     <label class="form-image">
       <span class="image-file">画像</span>
-      <input type="file" class="hidden">
+      <%= f.file_field :image, class: 'hidden' %>
     </label>
   </div>
-  <input class="form-submit" type="submit" value="送信">
-</div>
+  <%= f.submit '送信', class: 'form-submit' %>
+<% end %>

--- a/app/views/messages/_main_chat.html.erb
+++ b/app/views/messages/_main_chat.html.erb
@@ -12,20 +12,7 @@
 </div>
 
 <div class="messages">
-  <div class="message">
-    <div class="upper-message">
-      <div class="message-user">
-        Tom
-      </div>
-      <div class="message-date">
-        2020/3/31(Wed) 12:43:30
-      </div>
-    </div>
-    <div class="lower-message">
-      <div class="message-content">
-        おはよう
-      </div>
-    </div>
+  <%= render partial: 'message', collection: @messages %>
   </div>
 
 <%= form_with model: [@room, @message], class: 'form', local: true do |f| %>

--- a/app/views/messages/_message.html.erb
+++ b/app/views/messages/_message.html.erb
@@ -6,7 +6,7 @@
     </div>
     <div class="message-date">
       <!-- 投稿した時刻を出力する -->
-      <%= message.created_at %>
+      <%= l message.created_at %>
     </div>
   </div>
   <div class="lower-message">

--- a/app/views/messages/_message.html.erb
+++ b/app/views/messages/_message.html.erb
@@ -1,0 +1,18 @@
+<div class="message">
+  <div class="upper-message">
+    <div class="message-user">
+      <!-- 投稿したユーザー名情報を出力する -->
+      <%= message.user.name %>
+    </div>
+    <div class="message-date">
+      <!-- 投稿した時刻を出力する -->
+      <%= message.created_at %>
+    </div>
+  </div>
+  <div class="lower-message">
+    <div class="message-content">
+      <!-- 投稿したメッセージ内容を記述する -->
+      <%= message.content %>
+    </div>
+  </div>
+</div>

--- a/app/views/messages/_side_bar.html.erb
+++ b/app/views/messages/_side_bar.html.erb
@@ -3,7 +3,7 @@
     <%= link_to current_user.name, edit_user_path(current_user) %>
   </div>
   <div class="create-room">
-    <%= link_to "チャットを作成する", new_room_path %>
+    <a href="#">チャットを作成する</a>
   </div>
 </div>
 
@@ -11,15 +11,9 @@
   <% current_user.rooms.each do |room| %>
     <div class="room">
       <div class="room-name">
-        <a href="#"><%= room.name %></a>
+        <%= link_to room.name, room_messages_path(room) %>
       </div>
     </div>
   <% end %>
 </div>
 
-  <div class="room">
-    <div class="room-name">
-      <a href="#">techroom2</a>
-    </div>
-  </div>
-</div>

--- a/app/views/rooms/new.html.erb
+++ b/app/views/rooms/new.html.erb
@@ -16,13 +16,13 @@
         <label class='chat-room-form__label' for='chat_room_チャットメンバー'>チャットメンバー</label>
       </div>
       <div class='chat-room-form__field--right'>
-       <select name="room[user_ids][]">
-          <option value="">チャットするユーザーを選択してください</option>
-          <% User.where.not(id: current_user.id).each do |user| %>
-    <option value=<%= user.id %>><%= user.name %></option>
-          <% end %>
-        </select>
-        <input name="room[user_ids][]" type="hidden" value=<%= current_user.id %>>
+ <select name="room[user_ids][]">
+  <option value="">チャットするユーザーを選択してください</option>
+  <% User.where.not(id: current_user.id).each do |user| %>
+    <option value=<%=user.id%>><%= user.name %></option>
+  <% end %>
+</select>
+<input name="room[user_ids][]" type="hidden" value=<%= current_user.id %>>
       </div>
     </div>
     <div class='chat-room-form__field'>
@@ -32,4 +32,3 @@
       </div>
     </div>
   <% end %>
-</div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -9,7 +9,9 @@ Bundler.require(*Rails.groups)
 module ChatApp
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults 6.0
+    config.load_defaults 6.0 
+    config.i18n.default_locale = :ja
+    config.time_zone = 'Tokyo'
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,4 @@
+ja:
+  time:
+    formats:
+      default: "%Y/%m/%d %H:%M:%S"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   devise_for :users
   root to: "rooms#index"
   resources :users, only: [:edit, :update]
-  resources :rooms, only: [:new, :create] do
+  resources :rooms, only: [:new, :create, :destroy] do
     resources :messages, only: [:index, :create]
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,7 @@ Rails.application.routes.draw do
   devise_for :users
   root to: "rooms#index"
   resources :users, only: [:edit, :update]
-  resources :rooms, only: [:new, :create]
+  resources :rooms, only: [:new, :create] do
+    resources :messages, only: [:index, :create]
+  end
 end

--- a/db/migrate/20210922145402_create_messages.rb
+++ b/db/migrate/20210922145402_create_messages.rb
@@ -1,0 +1,10 @@
+class CreateMessages < ActiveRecord::Migration[6.0]
+  def change
+    create_table :messages do |t|
+      t.string  :content
+      t.references :room, null: false, foreign_key: true
+      t.references :user, null: false, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_22_131756) do
+ActiveRecord::Schema.define(version: 2021_09_22_145402) do
+
+  create_table "messages", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "content"
+    t.bigint "room_id", null: false
+    t.bigint "user_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["room_id"], name: "index_messages_on_room_id"
+    t.index ["user_id"], name: "index_messages_on_user_id"
+  end
 
   create_table "room_users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "room_id", null: false
@@ -40,6 +50,8 @@ ActiveRecord::Schema.define(version: 2021_09_22_131756) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "messages", "rooms"
+  add_foreign_key "messages", "users"
   add_foreign_key "room_users", "rooms"
   add_foreign_key "room_users", "users"
 end


### PR DESCRIPTION
#Why
テキストの投稿機能を実装するため
投稿したテキストをメッセージ一覧画面に表示させるため
投稿時刻を日本時刻へ変更するため
テキストが空の状態ではテキストを送れないようにバリデーションを設定するため
現在のチャットルーム名をメッセージ一覧画面のヘッダーに表示するため
チャットルーム削除機能を実装するため

#What
メッセージ投稿をするための機能を実装するため
